### PR TITLE
New replacement pattern to pull metadata values in from the Data plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tpl/*
+!tpl/default

--- a/action.php
+++ b/action.php
@@ -15,6 +15,9 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
 
     private $tpl;
 
+    /** @var array The current page's Data-plugin keys and values */
+    private $data = array();
+
     /**
      * Constructor. Sets the correct template
      */
@@ -314,15 +317,18 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             $replaceable[strtolower($matches[1][$m])] = $matches[0][$m];
         }
 
-        // Set up SQLite, and retrieve this page's metadata
-        $sqlite = $helper->_getDB();
-        $sql = "SELECT key, value
-            FROM pages JOIN data ON data.pid=pages.pid
-            WHERE pages.page = '".$id."'";
-        $rows = $sqlite->res2arr($sqlite->query($sql));
+        // If not already done for this page, set up SQLite and retrieve this
+        // page's metadata
+        if (!isset($this->data[$id])) {
+            $sqlite = $helper->_getDB();
+            $sql = "SELECT key, value
+                FROM pages JOIN data ON data.pid=pages.pid
+                WHERE pages.page = '".$id."'";
+            $this->data[$id] = $sqlite->res2arr($sqlite->query($sql));
+        }
 
         // Get replacement values and build the replacement array
-        foreach ($rows as $row) {
+        foreach ($this->data[$id] as $row) {
             if (isset($replaceable[$row['key']])) {
                 $replacements[$replaceable[$row['key']]] = $row['value'];
             }

--- a/action.php
+++ b/action.php
@@ -263,6 +263,50 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
     }
 
     /**
+     * Replace all @DATA:column@ patterns with values retrieved from the
+     * data plugin's metadata database.
+     * 
+     * @global string $ID The current page ID.
+     * @param string $html Input HTML, in which to find replacement strings.
+     * @return string HTML string with replacements made.
+     */
+    public function handleDataReplacements($html) {
+        global $ID;
+
+        // Load helper (or give up)
+        $helper = plugin_load('helper', 'data');
+        if ($helper == NULL) return $html;
+
+        // Find replacements (or give up)
+        $count = preg_match_all('/@DATA:(.*?)@/', $html, $matches);
+        if ($count < 1) return $html;
+        $replaceable = array();
+        for ($m=0; $m<count($matches[0]); $m++) {
+            $replaceable[strtolower($matches[1][$m])] = $matches[0][$m];
+        }
+
+        // Set up SQLite, and retrieve this page's metadata
+        $sqlite = $helper->_getDB();
+        $sql = "SELECT key, value
+            FROM pages JOIN data ON data.pid=pages.pid
+            WHERE pages.page = '".$ID."'";
+        $rows = $sqlite->res2arr($sqlite->query($sql));
+
+        // Get replacement values and build the replacement array
+        $replace = array();
+        foreach ($rows as $row) {
+            if (isset($replaceable[$row['key']])) {
+                $replace[$replaceable[$row['key']]] = $row['value'];
+            }
+        }
+
+        // Perform replacements
+        $html = str_replace(array_keys($replace), array_values($replace), $html);
+
+        return $html;
+    }
+
+    /**
      * Load all the style sheets and apply the needed replacements
      */
     protected function load_css(){


### PR DESCRIPTION
Patterns are of the form: `@DATA:column@` where `column` is a Data-plugin key name as defined in the `----dataentry----` section of the page being exported to PDF.

This checks for the presence of the Data plugin, and does no replacements (but still works fine) if it's not found.

(I think this is a better idea than my earlier attempt (#22) at getting a document-specific 'revision-number' into the PDF footer. `:-)` Of course, I'm very open to be shown a better way!)
