### PR TITLE
Fixed config accessor for HTML debug output.

### DIFF
--- a/action.php
+++ b/action.php
@@ -199,7 +199,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             $html .= '</html>';
 
             //Return html for debugging
-            if($conf['allowdebug'] && $_GET['debughtml'] == 'html') {
+            if($this->getConf('allowdebug') && $_GET['debughtml'] == 'html') {
                 echo $html;
                 exit();
             };


### PR DESCRIPTION
Shoot me down if I'm misunderstanding this, but I noticed that there might some inconsistency with usage of `$conf[]` and `$this->getConf()`, whereby the former is a wiki level global config object and the latter is to retrieve the plugin configs, right?

If that's true, then the reason why the fix below seems to have made HTML debug export work for me is because it's looking in the right place now.

Possibly the same problem might exist on line [399](https://github.com/splitbrain/dokuwiki-plugin-dw2pdf/blob/master/action.php#L399) and line [406](https://github.com/splitbrain/dokuwiki-plugin-dw2pdf/blob/master/action.php#L406) but I don't have time right now to test those.
