### PR TITLE
Custom variables in PDF template.

### DIFF
--- a/action.php
+++ b/action.php
@@ -394,6 +394,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
      */
     protected function load_template($title) {
         global $ID;
+        global $REV;   // required for additional replacement variables
         global $conf;
 
         // this is what we'll return
@@ -440,6 +441,27 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             '@BASE@'    => DOKU_BASE,
             '@TPLBASE@' => DOKU_BASE . 'lib/plugins/dw2pdf/tpl/' . $this->tpl . '/'
         );
+
+        // get page content
+        $rawfile = wikiFN($ID,$REV);
+        $rawpagetext = io_readWikiPage($rawfile,$ID,$REV);
+        //get variable definitions for replacement
+        $data = array();
+        if (preg_match('/<pdfvars[^>]*>([^<]*)<\/pdfvars>/', $rawpagetext, $data) > 0) {
+            //split entries
+            $data = array_pop($data);
+            $data = preg_split('/[\r\n]+/', $data, -1, PREG_SPLIT_NO_EMPTY);
+            
+            //process wiki-data
+            foreach ($data as $entry) {
+                //normal variable definition
+                $item = explode("=", trim($entry));
+                if (count($item) === 2) {
+                    // add var to array
+                    $replace[("@" . trim($item[0]) . "@")] = $item[1];
+                }
+            }
+        }
 
         // set HTML element
         $html = str_replace(array_keys($replace), array_values($replace), $html);

--- a/syntax.php
+++ b/syntax.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * DokuWiki Plugin dw2pdf (Syntax Component) 
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  lisps    
+ */
+ 
+// must be run within DokuWiki
+if(!defined('DOKU_INC')) die();
+ 
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once DOKU_PLUGIN.'syntax.php';
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_dw2pdf extends DokuWiki_Syntax_Plugin {
+ 
+ 
+	function getType() { return 'substition'; }
+	function getSort() { return 32; }
+ 
+	function connectTo($mode) {
+		$this->Lexer->addSpecialPattern('<pdfvars[^>]*>[^<]*</pdfvars>',$mode,'plugin_dw2pdf');
+	}
+ 
+	function handle($match, $state, $pos, Doku_Handler &$handler) {
+		return array($match, $state, $pos);
+	}
+ 
+	function render($mode, Doku_Renderer &$renderer, $data) {
+	// $data is what the function handle return'ed.
+		if($mode == 'xhtml'){
+			$renderer->doc .="";
+			return true;
+		}
+		return false;
+	}
+}
+


### PR DESCRIPTION
Hello,

I have feature proposition for dw2pdf plugin. In some cases some information in header and footer, are not enough. So I make modification in plugin for implementation of custom variables.

Simply use in DokuWiki page sintax:

<pdfvars>
varname1=value1
varname2=value2
...
</pdfvars>

block to define custom variables, and then in header / footer template use @varname@ for replacement just like standard ones. I hope that it will be useful also for other users.

I tested it on my local test wiki instance and it works. But my knowledge of PHP is very, very limited.
In fact I reuse code (and idea) from const plugin, and use my universal programming experience.
Not tested with bookcreator, but I think that it will not interfere with it.

regards,
Davor