### PR TITLE
Include the parallel page if no conf[start]

### DIFF
--- a/action.php
+++ b/action.php
@@ -192,7 +192,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             }
 
             if ($pdfnamespace !== '') {
-                if (!in_array($pdfnamespace . ':start', $list, true)) {
+                if (!in_array($pdfnamespace . ':' . $conf['start'], $list, true)) {
                     if (file_exists(wikiFN(rtrim($pdfnamespace,':')))) {
                         array_unshift($list,rtrim($pdfnamespace,':'));
                     }

--- a/action.php
+++ b/action.php
@@ -191,6 +191,14 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
                 $list[] = $item['id'];
             }
 
+            if ($pdfnamespace !== '') {
+                if (!in_array($pdfnamespace . ':start', $list, true)) {
+                    if (file_exists(wikiFN(rtrim($pdfnamespace,':')))) {
+                        array_unshift($list,rtrim($pdfnamespace,':'));
+                    }
+                }
+            }
+
         } elseif(isset($_COOKIE['list-pagelist']) && !empty($_COOKIE['list-pagelist'])) {
             //is in Bookmanager of bookcreator plugin a title given?
             if(!$title = $INPUT->str('pdfbook_title')) {


### PR DESCRIPTION
If the conf[start] page of a namespace does not exists a page parallel to the namespace with the same name as the namespace may be used as startpage by Dokuwiki. The expected behavior is, that this page is in these cases also included in the namespace-wide pdf.

**However:**
Dokuwiki and Indexmenu handle the startpage differently.
* Dokuwiki: If there is no conf[start]-page in a namespace, a page with the same name as the namespace which is **within** the namespace is chosen second. Only if that page does not exist, then a page with the same name as the namespace which lies parallel to the namespace is chosen.
* Indexmenu: When clicking upon a folder(namespace) and there is no conf[start]-page, then it looks first for a page parallel to that namespace and only if it not successful, then it looks for a page within that folder.

This Pull-Request currently implements the Indexmenu-approach