### PR TITLE
Changed style.css to keep pagetool icon on left side for rtl languages

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,4 +20,9 @@
 #dokuwiki__pagetools ul li a.export_pdf:focus {
     background-position: right -45px;
 }
-
+/*Keep pagetool icon on left side for rtl languages*/
+[dir=rtl] #dokuwiki__pagetools ul li a.export_pdf:hover,
+#dokuwiki__pagetools ul li a.export_pdf:active,
+#dokuwiki__pagetools ul li a.export_pdf:focus {
+    background-position: left -45px;
+}


### PR DESCRIPTION
Changed style to put the page tool icon on the left side of the text when using a right to left written language. This keeps the icon from covering any text. 