### PR TITLE
Check acl, continues export with book_skipforbiddenpages=1 is set

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -6,3 +6,4 @@ $lang['needns']            = "Please provide an existing namespace.";
 $lang['empty']             = "You don't have pages selected yet.";
 $lang['tocheader']         = "Table of Contents";
 $lang['export_ns']         = 'Export namespace "%s:" to file %s.pdf';
+$lang['forbidden']         = "You have no access to these pages: %s. Use option 'Skip Forbidden Pages' or add '&book_skipforbiddenpages=1' to your export-url";

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -6,4 +6,4 @@ $lang['needns']            = "Please provide an existing namespace.";
 $lang['empty']             = "You don't have pages selected yet.";
 $lang['tocheader']         = "Table of Contents";
 $lang['export_ns']         = 'Export namespace "%s:" to file %s.pdf';
-$lang['forbidden']         = "You have no access to these pages: %s. Use option 'Skip Forbidden Pages' or add '&book_skipforbiddenpages=1' to your export-url";
+$lang['forbidden']         = "You have no access to these pages: %s.<br/><br/>Use option 'Skip Forbidden Pages' to create your book with the available pages.";


### PR DESCRIPTION
Default it shows a message which warns that selection contains acl protected pages.
To continue the url parameter `book_skipforbiddenpages=1` is required.
