### PR TITLE
Change order to load CSS

### DIFF
--- a/action.php
+++ b/action.php
@@ -373,7 +373,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         $styles .= 'div.dw2pdf-landscape { page:landscape-page }';
         $styles .= '@page portrait-page { size:portrait }';
         $styles .= 'div.dw2pdf-portrait { page:portrait-page }';
-		$styles .= $this->load_css();
+        $styles .= $this->load_css();
         
         $mpdf->WriteHTML($styles, 1);
 

--- a/action.php
+++ b/action.php
@@ -365,15 +365,16 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             $html .= '<html><head>';
             $html .= '<style type="text/css">';
         }
-        $styles = $this->load_css();
-        $styles .= '@page { size:auto; ' . $template['page'] . '}';
+        
+        $styles = '@page { size:auto; ' . $template['page'] . '}';
         $styles .= '@page :first {' . $template['first'] . '}';
 
         $styles .= '@page landscape-page { size:landscape }';
         $styles .= 'div.dw2pdf-landscape { page:landscape-page }';
         $styles .= '@page portrait-page { size:portrait }';
         $styles .= 'div.dw2pdf-portrait { page:portrait-page }';
-
+		$styles .= $this->load_css();
+        
         $mpdf->WriteHTML($styles, 1);
 
         if($isDebug) {


### PR DESCRIPTION
If you load the own CSS-File first you can't overwrite the page-settings. It's better to load the own CSS-File at last.