### PR TITLE
Fix missing images by injecting ImageProcessor Decorator

### DIFF
--- a/DokuImageProcessorDecorator.class.php
+++ b/DokuImageProcessorDecorator.class.php
@@ -45,8 +45,6 @@ class DokuImageProcessorDecorator extends \Mpdf\Image\ImageProcessor {
                 if(preg_match('/[\?&]w=(\d+)/', $file, $m)) $w = $m[1];
                 if(preg_match('/[\?&]h=(\d+)/', $file, $m)) $h = $m[1];
 
-                dbglog($media, __FILE__ . ': ' . __LINE__);
-                dbglog(media_isexternal($media), __FILE__ . ': ' . __LINE__);
                 if(media_isexternal($media)) {
                     $local = media_get_from_URL($media, $ext, -1);
                     if(!$local) $local = $media; // let mpdf try again

--- a/DokuImageProcessorDecorator.class.php
+++ b/DokuImageProcessorDecorator.class.php
@@ -1,0 +1,82 @@
+<?php
+
+class DokuImageProcessorDecorator extends \Mpdf\Image\ImageProcessor {
+
+    /**
+     * Override the mpdf _getImage function
+     *
+     * This function takes care of gathering the image data from HTTP or
+     * local files before passing the data back to mpdf's original function
+     * making sure that only cached file paths are passed to mpdf. It also
+     * takes care of checking image ACls.
+     */
+    public function getImage (&$file, $firsttime = true, $allowvector = true, $orig_srcpath = false, $interpolation = false) {
+        global $conf;
+
+        // build regex to parse URL back to media info
+        $re = preg_quote(ml('xxx123yyy', '', true, '&', true), '/');
+        $re = str_replace('xxx123yyy', '([^&\?]*)', $re);
+
+        // extract the real media from a fetch.php uri and determine mime
+        if(preg_match("/^$re/", $file, $m) ||
+            preg_match('/[&\?]media=([^&\?]*)/', $file, $m)
+        ) {
+            $media = rawurldecode($m[1]);
+            list($ext, $mime) = mimetype($media);
+        } else {
+            list($ext, $mime) = mimetype($file);
+        }
+
+        // local files
+        $local = '';
+        if(substr($file, 0, 9) == 'dw2pdf://') {
+            // support local files passed from plugins
+            $local = substr($file, 9);
+        } elseif(!preg_match('/(\.php|\?)/', $file)) {
+            $re = preg_quote(DOKU_URL, '/');
+            // directly access local files instead of using HTTP, skip dynamic content
+            $local = preg_replace("/^$re/i", DOKU_INC, $file);
+        }
+
+        if(substr($mime, 0, 6) == 'image/') {
+            if(!empty($media)) {
+                // any size restrictions?
+                $w = $h = 0;
+                if(preg_match('/[\?&]w=(\d+)/', $file, $m)) $w = $m[1];
+                if(preg_match('/[\?&]h=(\d+)/', $file, $m)) $h = $m[1];
+
+                dbglog($media, __FILE__ . ': ' . __LINE__);
+                dbglog(media_isexternal($media), __FILE__ . ': ' . __LINE__);
+                if(media_isexternal($media)) {
+                    $local = media_get_from_URL($media, $ext, -1);
+                    if(!$local) $local = $media; // let mpdf try again
+                } else {
+                    $media = cleanID($media);
+                    //check permissions (namespace only)
+                    if(auth_quickaclcheck(getNS($media) . ':X') < AUTH_READ) {
+                        $file = '';
+                    }
+                    $local = mediaFN($media);
+                }
+
+                //handle image resizing/cropping
+                if($w && file_exists($local)) {
+                    if($h) {
+                        $local = media_crop_image($local, $ext, $w, $h);
+                    } else {
+                        $local = media_resize_image($local, $ext, $w, $h);
+                    }
+                }
+            } elseif(media_isexternal($file)) { // fixed external URLs
+                $local = media_get_from_URL($file, $ext, $conf['cachetime']);
+            }
+
+            if($local) {
+                $file = $local;
+                $orig_srcpath = $local;
+            }
+        }
+
+        return parent::getImage($file, $firsttime, $allowvector, $orig_srcpath, $interpolation);
+    }
+}

--- a/DokuPDF.class.php
+++ b/DokuPDF.class.php
@@ -12,6 +12,7 @@ if(!defined('_MPDF_TEMP_PATH')) define('_MPDF_TEMP_PATH', $conf['tmpdir'] . '/dw
 if(!defined('_MPDF_TTFONTDATAPATH')) define('_MPDF_TTFONTDATAPATH', $conf['cachedir'] . '/mpdf_ttf/');
 
 require_once __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/DokuImageProcessorDecorator.class.php';
 
 /**
  * Class DokuPDF
@@ -47,9 +48,11 @@ class DokuPDF extends \Mpdf\Mpdf {
             array(
                 'mode' => $mode,
                 'format' => $format,
-                'fontsize' => $fontsize
+                'fontsize' => $fontsize,
+                'ImageProcessorClass' => DokuImageProcessorDecorator::class,
             )
         );
+
         $this->autoScriptToLang = true;
         $this->baseScript = 1;
         $this->autoVietnamese = true;
@@ -74,81 +77,4 @@ class DokuPDF extends \Mpdf\Mpdf {
         $path = htmlspecialchars_decode($path);
         parent::GetFullPath($path, $basepath);
     }
-
-    /**
-     * Override the mpdf _getImage function
-     *
-     * This function takes care of gathering the image data from HTTP or
-     * local files before passing the data back to mpdf's original function
-     * making sure that only cached file paths are passed to mpdf. It also
-     * takes care of checking image ACls.
-     */
-    function _getImage(&$file, $firsttime = true, $allowvector = true, $orig_srcpath = false, $interpolation = false) {
-        global $conf;
-
-        // build regex to parse URL back to media info
-        $re = preg_quote(ml('xxx123yyy', '', true, '&', true), '/');
-        $re = str_replace('xxx123yyy', '([^&\?]*)', $re);
-
-        // extract the real media from a fetch.php uri and determine mime
-        if(preg_match("/^$re/", $file, $m) ||
-            preg_match('/[&\?]media=([^&\?]*)/', $file, $m)
-        ) {
-            $media = rawurldecode($m[1]);
-            list($ext, $mime) = mimetype($media);
-        } else {
-            list($ext, $mime) = mimetype($file);
-        }
-
-        // local files
-        $local = '';
-        if(substr($file, 0, 9) == 'dw2pdf://') {
-            // support local files passed from plugins
-            $local = substr($file, 9);
-        } elseif(!preg_match('/(\.php|\?)/', $file)) {
-            $re = preg_quote(DOKU_URL, '/');
-            // directly access local files instead of using HTTP, skip dynamic content
-            $local = preg_replace("/^$re/i", DOKU_INC, $file);
-        }
-
-        if(substr($mime, 0, 6) == 'image/') {
-            if(!empty($media)) {
-                // any size restrictions?
-                $w = $h = 0;
-                if(preg_match('/[\?&]w=(\d+)/', $file, $m)) $w = $m[1];
-                if(preg_match('/[\?&]h=(\d+)/', $file, $m)) $h = $m[1];
-
-                if(media_isexternal($media)) {
-                    $local = media_get_from_URL($media, $ext, -1);
-                    if(!$local) $local = $media; // let mpdf try again
-                } else {
-                    $media = cleanID($media);
-                    //check permissions (namespace only)
-                    if(auth_quickaclcheck(getNS($media) . ':X') < AUTH_READ) {
-                        $file = '';
-                    }
-                    $local = mediaFN($media);
-                }
-
-                //handle image resizing/cropping
-                if($w && file_exists($local)) {
-                    if($h) {
-                        $local = media_crop_image($local, $ext, $w, $h);
-                    } else {
-                        $local = media_resize_image($local, $ext, $w, $h);
-                    }
-                }
-            } elseif(media_isexternal($file)) { // fixed external URLs
-                $local = media_get_from_URL($file, $ext, $conf['cachetime']);
-            }
-
-            if($local) {
-                $file = $local;
-                $orig_srcpath = $local;
-            }
-        }
-
-        return parent::_getImage($file, $firsttime, $allowvector, $orig_srcpath, $interpolation);
-    }
-
 }

--- a/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -2,17 +2,37 @@
 
 namespace Mpdf\Config;
 
+use Mpdf\Cache;
+use Mpdf\Color\ColorConverter;
+use Mpdf\Color\ColorModeConverter;
+use Mpdf\Color\ColorSpaceRestrictor;
 use Mpdf\Css\DefaultCss;
 
+use Mpdf\CssManager;
+use Mpdf\Fonts\FontCache;
+use Mpdf\Fonts\FontFileFinder;
+use Mpdf\Form;
+use Mpdf\Gradient;
+use Mpdf\Hyphenator;
+use Mpdf\Image\ImageProcessor;
 use Mpdf\Language\LanguageToFont;
 use Mpdf\Language\ScriptToLanguage;
 
+use Mpdf\MpdfException;
+use Mpdf\Otl;
+use Mpdf\SizeConverter;
+use Mpdf\TableOfContents;
+use Mpdf\Tag;
 use Mpdf\Ucdn;
+
+use Psr\Log\NullLogger;
+
 
 class ConfigVariables
 {
 
 	private $defaults;
+	private $defaultClasses;
 
 	public function __construct()
 	{
@@ -502,10 +522,35 @@ class ConfigVariables
 			'curlAllowUnsafeSslRequests' => false,
 			'curlTimeout' => 5,
 		];
+
+		$this->defaultClasses = [
+		    'SizeConverterClass' => SizeConverter::class,
+		    'ColorModeConverterClass' => ColorModeConverter::class,
+		    'ColorSpaceRestrictorClass' => ColorSpaceRestrictor::class,
+		    'ColorConverterClass' => ColorConverter::class,
+		    'GradientClass' => Gradient::class,
+		    'TableOfContentsClass' => TableOfContents::class,
+		    'CacheClass' => Cache::class,
+		    'FontCacheClass' => FontCache::class,
+		    'FontFileFinderClass' => FontFileFinder::class,
+		    'CssManagerClass' => CssManager::class,
+		    'OtlClass' => Otl::class,
+		    'FormClass' => Form::class,
+		    'HyphenatorClass' => Hyphenator::class,
+		    'NullLoggerClass' => NullLogger::class,
+		    'ImageProcessorClass' => ImageProcessor::class,
+		    'TagClass' => Tag::class,
+		    'MpdfExceptionClass' => MpdfException::class,
+        ];
 	}
 
 	public function getDefaults()
 	{
 		return $this->defaults;
 	}
+
+    public function getDefaultClasses()
+    {
+        return $this->defaultClasses;
+    }
 }

--- a/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -524,24 +524,24 @@ class ConfigVariables
 		];
 
 		$this->defaultClasses = [
-		    'SizeConverterClass' => SizeConverter::class,
-		    'ColorModeConverterClass' => ColorModeConverter::class,
-		    'ColorSpaceRestrictorClass' => ColorSpaceRestrictor::class,
-		    'ColorConverterClass' => ColorConverter::class,
-		    'GradientClass' => Gradient::class,
-		    'TableOfContentsClass' => TableOfContents::class,
-		    'CacheClass' => Cache::class,
-		    'FontCacheClass' => FontCache::class,
-		    'FontFileFinderClass' => FontFileFinder::class,
-		    'CssManagerClass' => CssManager::class,
-		    'OtlClass' => Otl::class,
-		    'FormClass' => Form::class,
-		    'HyphenatorClass' => Hyphenator::class,
-		    'NullLoggerClass' => NullLogger::class,
-		    'ImageProcessorClass' => ImageProcessor::class,
-		    'TagClass' => Tag::class,
-		    'MpdfExceptionClass' => MpdfException::class,
-        ];
+			'SizeConverterClass' => SizeConverter::class,
+			'ColorModeConverterClass' => ColorModeConverter::class,
+			'ColorSpaceRestrictorClass' => ColorSpaceRestrictor::class,
+			'ColorConverterClass' => ColorConverter::class,
+			'GradientClass' => Gradient::class,
+			'TableOfContentsClass' => TableOfContents::class,
+			'CacheClass' => Cache::class,
+			'FontCacheClass' => FontCache::class,
+			'FontFileFinderClass' => FontFileFinder::class,
+			'CssManagerClass' => CssManager::class,
+			'OtlClass' => Otl::class,
+			'FormClass' => Form::class,
+			'HyphenatorClass' => Hyphenator::class,
+			'NullLoggerClass' => NullLogger::class,
+			'ImageProcessorClass' => ImageProcessor::class,
+			'TagClass' => Tag::class,
+			'MpdfExceptionClass' => MpdfException::class,
+		];
 	}
 
 	public function getDefaults()
@@ -549,8 +549,8 @@ class ConfigVariables
 		return $this->defaults;
 	}
 
-    public function getDefaultClasses()
-    {
-        return $this->defaultClasses;
-    }
+	public function getDefaultClasses()
+	{
+		return $this->defaultClasses;
+	}
 }

--- a/vendor/mpdf/mpdf/src/Mpdf.php
+++ b/vendor/mpdf/mpdf/src/Mpdf.php
@@ -8,24 +8,13 @@ use pdf_parser;
 use Mpdf\Config\ConfigVariables;
 use Mpdf\Config\FontVariables;
 
-use Mpdf\Color\ColorConverter;
-use Mpdf\Color\ColorModeConverter;
-use Mpdf\Color\ColorSpaceRestrictor;
-
 use Mpdf\Conversion;
 
 use Mpdf\Css\Border;
 use Mpdf\Css\TextVars;
 
-use Mpdf\Image\ImageProcessor;
-
-use Mpdf\Language\LanguageToFont;
-use Mpdf\Language\ScriptToLanguage;
-
 use Mpdf\Log\Context as LogContext;
 
-use Mpdf\Fonts\FontCache;
-use Mpdf\Fonts\FontFileFinder;
 use Mpdf\Fonts\MetricsGenerator;
 
 use Mpdf\Output\Destination;
@@ -36,7 +25,6 @@ use Mpdf\Pdf\Protection\UniqidGenerator;
 use Mpdf\QrCode;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * mPDF, PHP library generating PDF files from UTF-8 encoded HTML
@@ -801,7 +789,25 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	var $outerblocktags;
 	var $innerblocktags;
 
-	/**
+    // holds the classes used in the constructor
+    protected $SizeConverterClass;
+    protected $ColorModeConverterClass;
+    protected $ColorSpaceRestrictorClass;
+    protected $ColorConverterClass;
+    protected $GradientClass;
+    protected $TableOfContentsClass;
+    protected $CacheClass;
+    protected $FontCacheClass;
+    protected $FontFileFinderClass;
+    protected $CssManagerClass;
+    protected $FormClass;
+    protected $HyphenatorClass;
+    protected $NullLoggerClass;
+    protected $ImageProcessorClass;
+    protected $TagClass;
+    protected $OtlClass;
+
+    /**
 	 * @var string
 	 */
 	private $fontDescriptor;
@@ -956,36 +962,36 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$originalConfig = $config;
 		$config = $this->initConfig($originalConfig);
 
-		$this->sizeConverter = new SizeConverter($this->dpi, $this->default_font_size);
+		$this->sizeConverter = new $this->SizeConverterClass($this->dpi, $this->default_font_size);
 
-		$this->colorModeConverter = new ColorModeConverter();
-		$this->colorSpaceRestrictor = new ColorSpaceRestrictor(
+		$this->colorModeConverter = new $this->ColorModeConverterClass();
+		$this->colorSpaceRestrictor = new $this->ColorSpaceRestrictorClass(
 			$this,
 			$this->colorModeConverter,
 			$this->restrictColorSpace
 		);
-		$this->colorConverter = new ColorConverter($this, $this->colorModeConverter, $this->colorSpaceRestrictor);
+		$this->colorConverter = new $this->ColorConverterClass($this, $this->colorModeConverter, $this->colorSpaceRestrictor);
 
 
-		$this->gradient = new Gradient($this, $this->sizeConverter, $this->colorConverter);
-		$this->tableOfContents = new TableOfContents($this, $this->sizeConverter);
+		$this->gradient = new $this->GradientClass($this, $this->sizeConverter, $this->colorConverter);
+		$this->tableOfContents = new $this->TableOfContentsClass($this, $this->sizeConverter);
 
-		$this->cache = new Cache($config['tempDir']);
-		$this->fontCache = new FontCache(new Cache($config['tempDir'] . '/ttfontdata'));
+		$this->cache = new $this->CacheClass($config['tempDir']);
+		$this->fontCache = new $this->FontCacheClass(new $this->CacheClass($config['tempDir'] . '/ttfontdata'));
 
-		$this->fontFileFinder = new FontFileFinder($config['fontDir']);
+		$this->fontFileFinder = new $this->FontFileFinderClass($config['fontDir']);
 
-		$this->cssManager = new CssManager($this, $this->cache, $this->sizeConverter, $this->colorConverter);
+		$this->cssManager = new $this->CssManagerClass($this, $this->cache, $this->sizeConverter, $this->colorConverter);
 
-		$this->otl = new Otl($this, $this->fontCache);
+		$this->otl = new $this->OtlClass($this, $this->fontCache);
 
-		$this->form = new Form($this, $this->otl, $this->colorConverter);
+		$this->form = new $this->FormClass($this, $this->otl, $this->colorConverter);
 
-		$this->hyphenator = new Hyphenator($this);
+		$this->hyphenator = new $this->HyphenatorClass($this);
 
-		$this->logger = new NullLogger();
+		$this->logger = new $this->NullLoggerClass();
 
-		$this->imageProcessor = new ImageProcessor(
+		$this->imageProcessor = new $this->ImageProcessorClass(
 			$this,
 			$this->otl,
 			$this->cssManager,
@@ -997,7 +1003,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$this->logger
 		);
 
-		$this->tag = new Tag(
+		$this->tag = new $this->TagClass(
 			$this,
 			$this->cache,
 			$this->cssManager,
@@ -1531,7 +1537,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	{
 		$configObject = new ConfigVariables();
 		$defaults = $configObject->getDefaults();
-		$config = array_intersect_key($config + $defaults, $defaults);
+		$defaultClasses = $configObject->getDefaultClasses();
+		$combinedDefaults = $defaults + $defaultClasses;
+		$config = array_intersect_key($config + $combinedDefaults, $combinedDefaults);
 
 		foreach ($config as $var => $val) {
 			$this->{$var} = $val;

--- a/vendor/mpdf/mpdf/src/Mpdf.php
+++ b/vendor/mpdf/mpdf/src/Mpdf.php
@@ -789,25 +789,25 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	var $outerblocktags;
 	var $innerblocktags;
 
-    // holds the classes used in the constructor
-    protected $SizeConverterClass;
-    protected $ColorModeConverterClass;
-    protected $ColorSpaceRestrictorClass;
-    protected $ColorConverterClass;
-    protected $GradientClass;
-    protected $TableOfContentsClass;
-    protected $CacheClass;
-    protected $FontCacheClass;
-    protected $FontFileFinderClass;
-    protected $CssManagerClass;
-    protected $FormClass;
-    protected $HyphenatorClass;
-    protected $NullLoggerClass;
-    protected $ImageProcessorClass;
-    protected $TagClass;
-    protected $OtlClass;
+	// holds the classes used in the constructor
+	protected $SizeConverterClass;
+	protected $ColorModeConverterClass;
+	protected $ColorSpaceRestrictorClass;
+	protected $ColorConverterClass;
+	protected $GradientClass;
+	protected $TableOfContentsClass;
+	protected $CacheClass;
+	protected $FontCacheClass;
+	protected $FontFileFinderClass;
+	protected $CssManagerClass;
+	protected $FormClass;
+	protected $HyphenatorClass;
+	protected $NullLoggerClass;
+	protected $ImageProcessorClass;
+	protected $TagClass;
+	protected $OtlClass;
 
-    /**
+	/**
 	 * @var string
 	 */
 	private $fontDescriptor;


### PR DESCRIPTION
This implements the changes in mpdf/mpdf#460

In the new mpdf library, the `_getImage()` function is no longer part of the main `Mpdf` class and hence our own decorator for that function is no longer called.

This should fix #287 and should fix #286