### PR TITLE
Allow overwriting the output configuration option

### DIFF
--- a/action.php
+++ b/action.php
@@ -478,9 +478,16 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         header('Cache-Control: must-revalidate, no-transform, post-check=0, pre-check=0');
         header('Pragma: public');
         http_conditionalRequest(filemtime($cachefile));
+        global $INPUT;
+        if ($INPUT->has('outputTarget')) {
+            $outputTarget = $INPUT->str('outputTarget');
+        }
+        if (empty($outputTarget)) {
+            $outputTarget = $this->getConf('output');
+        }
 
         $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
-        if($this->getConf('output') == 'file') {
+        if($outputTarget === 'file') {
             header('Content-Disposition: attachment; filename="' . $filename . '.pdf";');
         } else {
             header('Content-Disposition: inline; filename="' . $filename . '.pdf";');

--- a/action.php
+++ b/action.php
@@ -479,12 +479,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         header('Pragma: public');
         http_conditionalRequest(filemtime($cachefile));
         global $INPUT;
-        if ($INPUT->has('outputTarget')) {
-            $outputTarget = $INPUT->str('outputTarget');
-        }
-        if (empty($outputTarget)) {
-            $outputTarget = $this->getConf('output');
-        }
+        $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));
 
         $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
         if($outputTarget === 'file') {


### PR DESCRIPTION
Currently, the export via bookcreator-plugin fails if the configuration `output` is set to `Browser`.
With this pull request, the bookcreator-plugin can supply `outputTarget=file` to force the output
as download.