### PR TITLE
bookmarklevels may rise by 'only' +1

### DIFF
--- a/_test/renderer_dw2pdf.test.php
+++ b/_test/renderer_dw2pdf.test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * General tests for the dw2pdf renderer of dw2pdf plugin
+ *
+ * @group plugin_dw2pdf
+ * @group plugins
+ */
+
+class renderer_plugin_dw2pdfdummy extends renderer_plugin_dw2pdf {
+
+    /**
+     * @param int $level 1-6
+     * @return int
+     */
+    public function getCalculateBookmarklevel($level) {
+        return $this->calculateBookmarklevel($level);
+    }
+}
+
+/**
+ * Class dw2pdf_renderer_dw2pdf_test
+ */
+class dw2pdf_renderer_dw2pdf_test extends DokuWikiTest {
+
+    public function setUp() {
+        parent::setUp();
+    }
+
+
+    public function test() {
+        $Renderer = new renderer_plugin_dw2pdfdummy();
+
+        $levels = [
+            1,2,2,2,3,4,5,6,5,4,3,2,1, // index:0-12
+            3,4,3,1,                   // 13-16
+            2,3,4,2,3,4,1,             // 17-23
+            3,4,3,2,1,                 // 24-28
+            3,4,2,1,                   // 29-32
+            3,5,6,5,6,4,6,3,1,         // 33-41
+            3,6,4,5,6,4,3,6,2,1,       // 42-51
+            2,3,2,3,3                  // 52-56
+        ];
+        $expectedbookmarklevels = [
+            0,1,1,1,2,3,4,5,4,3,2,1,0,
+            1,2,1,0,
+            1,2,3,1,2,3,0,
+            1,2,1,1,0,
+            1,2,1,0,
+            1,2,3,2,3,2,3,2,0,
+            1,2,2,3,4,2,2,3,1,0,
+            1,2,1,2,2
+        ];
+        foreach($levels as $i => $level) {
+            $actualbookmarklevel = $Renderer->getCalculateBookmarklevel($level);
+            $this->assertEquals($expectedbookmarklevels[$i], $actualbookmarklevel,"index:$i, lvl:$level");
+        }
+    }
+
+}

--- a/renderer.php
+++ b/renderer.php
@@ -7,7 +7,7 @@
  */
 
 // must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
+if(!defined('DOKU_INC')) die();
 
 /**
  * Render xhtml suitable as input for mpdf library
@@ -51,7 +51,7 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
      * @param $format
      * @return bool
      */
-    public function canRender($format){
+    public function canRender($format) {
         if($format == 'xhtml') return true;
         return false;
     }
@@ -108,7 +108,7 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
         if($step > 1) {
             $this->difference = $this->difference + ($step - 1);
         }
-        if($step < 0 ) {
+        if($step < 0) {
             $this->difference = min($this->difference, $level - $this->originalHeaderLevel);
             $this->difference = max($this->difference, 0);
         }
@@ -137,14 +137,14 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
      */
     function locallink($hash, $name = null, $returnonly = false) {
         global $ID;
-        $name  = $this->_getLinkTitle($name, $hash, $isImage);
-        $hash  = $this->_headerToLink($hash);
-        $title = $ID.' ↵';
+        $name = $this->_getLinkTitle($name, $hash, $isImage);
+        $hash = $this->_headerToLink($hash);
+        $title = $ID . ' ↵';
 
         $check = false;
         $pid = sectionID($ID, $check);
 
-        $this->doc .= '<a href="#'. $pid . '__' . $hash.'" title="'.$title.'" class="wikilink1">';
+        $this->doc .= '<a href="#' . $pid . '__' . $hash . '" title="' . $title . '" class="wikilink1">';
         $this->doc .= $name;
         $this->doc .= '</a>';
     }
@@ -161,17 +161,17 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
      * @param bool   $render    should the media be embedded inline or just linked
      * @return string
      */
-    function _media ($src, $title=NULL, $align=NULL, $width=NULL,
-                      $height=NULL, $cache=NULL, $render = true) {
+    function _media($src, $title = NULL, $align = NULL, $width = NULL,
+                    $height = NULL, $cache = NULL, $render = true) {
 
         $out = '';
-        if($align == 'center'){
+        if($align == 'center') {
             $out .= '<div align="center" style="text-align: center">';
         }
 
-        $out .= parent::_media ($src, $title, $align, $width, $height, $cache, $render);
+        $out .= parent::_media($src, $title, $align, $width, $height, $cache, $render);
 
-        if($align == 'center'){
+        if($align == 'center') {
             $out .= '</div>';
         }
 
@@ -193,7 +193,7 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
      * @param array $link
      * @return string
      */
-    function _formatLink($link){
+    function _formatLink($link) {
 
         // for internal links contains the title the pageid
         if(in_array($link['title'], $this->actioninstance->getExportedPages())) {
@@ -204,18 +204,17 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
             $link['url'] = "#" . $pid . '__' . $hash;
         }
 
-
         // prefix interwiki links with interwiki icon
-        if($link['name'][0] != '<' && preg_match('/\binterwiki iw_(.\w+)\b/',$link['class'],$m)){
-            if(file_exists(DOKU_INC.'lib/images/interwiki/'.$m[1].'.png')){
-                $img = DOKU_BASE.'lib/images/interwiki/'.$m[1].'.png';
-            }elseif(file_exists(DOKU_INC.'lib/images/interwiki/'.$m[1].'.gif')){
-                $img = DOKU_BASE.'lib/images/interwiki/'.$m[1].'.gif';
-            }else{
-                $img = DOKU_BASE.'lib/images/interwiki.png';
+        if($link['name'][0] != '<' && preg_match('/\binterwiki iw_(.\w+)\b/', $link['class'], $m)) {
+            if(file_exists(DOKU_INC . 'lib/images/interwiki/' . $m[1] . '.png')) {
+                $img = DOKU_BASE . 'lib/images/interwiki/' . $m[1] . '.png';
+            } elseif(file_exists(DOKU_INC . 'lib/images/interwiki/' . $m[1] . '.gif')) {
+                $img = DOKU_BASE . 'lib/images/interwiki/' . $m[1] . '.gif';
+            } else {
+                $img = DOKU_BASE . 'lib/images/interwiki.png';
             }
 
-            $link['name'] = '<img src="'.$img.'" width="16" height="16" style="vertical-align: center" class="'.$link['class'].'" />'.$link['name'];
+            $link['name'] = '<img src="' . $img . '" width="16" height="16" style="vertical-align: center" class="' . $link['class'] . '" />' . $link['name'];
         }
         return parent::_formatLink($link);
     }

--- a/renderer.php
+++ b/renderer.php
@@ -61,7 +61,7 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
      * @param int $level
      * @param int $pos
      */
-    function header($text, $level, $pos) {
+    public function header($text, $level, $pos) {
         if(!$text) return; //skip empty headlines
         global $ID;
 
@@ -74,36 +74,38 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
         $pid = sectionID($ID, $check);
         $hid = $pid . '__' . $hid;
 
-            // add PDF bookmark
+        // add PDF bookmark
         $bookmark = '';
         $bmlevel = $this->actioninstance->getExportConfig('maxbookmarks');
-        if($bmlevel && $bmlevel >= $level){
+        if($bmlevel && $bmlevel >= $level) {
             // PDF readers choke on invalid nested levels
 
-            if ($this->lastheadlevel == -1)
-            	$this->lastheadlevel = $level;
+            if($this->lastheadlevel == -1) {
+                $this->lastheadlevel = $level;
+            }
 
             $step = $level - $this->lastheadlevel;
 
-            if ($step > 0)
-            	$this->current_bookmark_level += 1;
-            else if ($step <0)  {
-            	$this->current_bookmark_level -= 1;
-                if ($this->current_bookmark_level < 0)
+            if($step > 0) {
+                $this->current_bookmark_level += 1;
+            } elseif($step < 0) {
+                $this->current_bookmark_level -= 1;
+                if($this->current_bookmark_level < 0) {
                     $this->current_bookmark_level = 0;
+                }
             }
 
             $this->lastheadlevel = $level;
 
-            $bookmark = '<bookmark content="'.$this->_xmlEntities($text).'" level="'.($this->current_bookmark_level).'" />';
+            $bookmark = '<bookmark content="' . $this->_xmlEntities($text) . '" level="' . ($this->current_bookmark_level) . '" />';
         }
 
         // print header
-        $this->doc .= DOKU_LF."<h$level>$bookmark";
+        $this->doc .= DOKU_LF . "<h$level>$bookmark";
         $this->doc .= "<a name=\"$hid\">";
         $this->doc .= $this->_xmlEntities($text);
         $this->doc .= "</a>";
-        $this->doc .= "</h$level>".DOKU_LF;
+        $this->doc .= "</h$level>" . DOKU_LF;
     }
 
     /**


### PR DESCRIPTION
It seems that bookmarklevels in pdf should only increase by +1
Of course this creates a mismatch between actual levels and
bookmarklevels. This patch flattens the nesting at the original level
were the mismatch started.

Fixes #218