### PR TITLE
Recognize pdf.less and use the style.css of the wrap plugin by default

### DIFF
--- a/action.php
+++ b/action.php
@@ -785,7 +785,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             $list[DOKU_PLUGIN . "$p/all.css"] = DOKU_BASE . "lib/plugins/$p/";
             $list[DOKU_PLUGIN . "$p/all.less"] = DOKU_BASE . "lib/plugins/$p/";
 
-            if(file_exists(DOKU_PLUGIN . "$p/pdf.css")) {
+            if(file_exists(DOKU_PLUGIN . "$p/pdf.css") || file_exists(DOKU_PLUGIN . "$p/pdf.less")) {
                 $list[DOKU_PLUGIN . "$p/pdf.css"] = DOKU_BASE . "lib/plugins/$p/";
                 $list[DOKU_PLUGIN . "$p/pdf.less"] = DOKU_BASE . "lib/plugins/$p/";
             } else {

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,6 +9,6 @@ $conf['maxbookmarks']     = 5;
 $conf['template']         = 'default';
 $conf['output']           = 'file';
 $conf['usecache']         = 1;
-$conf['usestyles']        = '';
+$conf['usestyles']        = 'wrap,';
 $conf['qrcodesize']       = '120x120';
 $conf['showexportbutton'] = 1;


### PR DESCRIPTION
The wrap plugin's styles are sufficiently simple that mpdf can handle them. Also, the print-styles of wrap are very bland, which constitutes a great loss for a plugin with the main focus on colorful styling. Finally the wrap plugin is widely spread, hence many users will benefit from this.

For the best result, this depends on the merge of selfthinker/dokuwiki_plugin_wrap#156