### PR TITLE
Fix text replacement images (eg. smileys or FIXME)

### DIFF
--- a/DokuImageProcessorDecorator.class.php
+++ b/DokuImageProcessorDecorator.class.php
@@ -67,7 +67,7 @@ class DokuImageProcessorDecorator extends \Mpdf\Image\ImageProcessor {
                         $local = media_resize_image($local, $ext, $w, $h);
                     }
                 }
-            } elseif(media_isexternal($file)) { // fixed external URLs
+            } elseif(!file_exists($local) && media_isexternal($file)) { // fixed external URLs
                 $local = media_get_from_URL($file, $ext, $conf['cachetime']);
             }
 

--- a/DokuImageProcessorDecorator.class.php
+++ b/DokuImageProcessorDecorator.class.php
@@ -11,6 +11,13 @@ class DokuImageProcessorDecorator extends \Mpdf\Image\ImageProcessor {
      * takes care of checking image ACls.
      */
     public function getImage (&$file, $firsttime = true, $allowvector = true, $orig_srcpath = false, $interpolation = false) {
+        list($file, $orig_srcpath) = self::adjustGetImageLinks($file, $orig_srcpath);
+
+        return parent::getImage($file, $firsttime, $allowvector, $orig_srcpath, $interpolation);
+    }
+
+
+    public static function adjustGetImageLinks($file, $orig_srcpath) {
         global $conf;
 
         // build regex to parse URL back to media info
@@ -77,6 +84,6 @@ class DokuImageProcessorDecorator extends \Mpdf\Image\ImageProcessor {
             }
         }
 
-        return parent::getImage($file, $firsttime, $allowvector, $orig_srcpath, $interpolation);
+        return [$file, $orig_srcpath];
     }
 }

--- a/_test/DokuImageProcessor.test.php
+++ b/_test/DokuImageProcessor.test.php
@@ -1,0 +1,65 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../DokuImageProcessorDecorator.class.php';
+
+/**
+ * General tests for the imagemap plugin
+ *
+ * @group plugin_dw2pdf
+ * @group plugins
+ */
+class dw2pdf_getImage_test extends DokuWikiTest
+{
+
+    /**
+     * @return array the Testdata
+     */
+    public function provideGetImageTestdata() {
+        global $conf;
+        $conf['mediadir'];
+        return [
+            [
+                DOKU_URL . 'lib/exe/fetch.php?tok=b0b7a3&media=http%3A%2F%2Fphp.net%2Fimages%2Fphp.gif',
+                DOKU_REL . 'lib/exe/fetch.php?tok=b0b7a3&media=http%3A%2F%2Fphp.net%2Fimages%2Fphp.gif',
+                'http://php.net/images/php.gif',
+                'http://php.net/images/php.gif',
+                'external image',
+            ],
+            [
+                DOKU_URL . 'lib/images/smileys/fixme.gif',
+                DOKU_REL . 'lib/images/smileys/fixme.gif',
+                DOKU_INC . 'lib/images/smileys/fixme.gif',
+                DOKU_INC . 'lib/images/smileys/fixme.gif',
+                'Replacement image / smiley',
+            ],
+            [
+                DOKU_URL . 'lib/exe/fetch.php?media=wiki:dokuwiki-128.png',
+                DOKU_REL . 'lib/exe/fetch.php?media=wiki:dokuwiki-128.png',
+                $conf['mediadir'] . '/wiki/dokuwiki-128.png',
+                $conf['mediadir'] . '/wiki/dokuwiki-128.png',
+                'Internal image',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetImageTestdata
+     *
+     * @param $input_file
+     * @param $input_orig_srcpath
+     * @param $expected_file
+     * @param $expected_orig_srcpath
+     * @param $msg
+     */
+    public function testGetImage($input_file, $input_orig_srcpath, $expected_file, $expected_orig_srcpath, $msg)
+    {
+
+        list($actual_file, $actual_orig_srcpath) = \DokuImageProcessorDecorator::adjustGetImageLinks($input_file,
+            $input_orig_srcpath);
+
+        $this->assertEquals($expected_file, $actual_file,  '$file ' . $msg);
+        $this->assertEquals($expected_orig_srcpath, $actual_orig_srcpath,  '$orig_srcpath ' . $msg);
+    }
+
+}


### PR DESCRIPTION
To ensure that text replacement images work in situations where any access to the server without authentication is blocked, we have to access them directly on the filesystem.