### PR TITLE
Use page name if no page title exists

### DIFF
--- a/action.php
+++ b/action.php
@@ -141,6 +141,10 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             if(empty($this->title)) {
                 $this->title = p_get_first_heading($ID);
             }
+            // use page name if title is still empty
+            if(empty($this->title)) {
+                $this->title = noNS($ID);
+            }
 
             $filename = wikiFN($ID, $REV);
             if(!file_exists($filename)) {
@@ -543,10 +547,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         global $INPUT;
         $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));
 
-        $filename = 'unknown';
-        if(!empty($this->title)) {
-            $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
-        }
+        $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
 
         if($outputTarget === 'file') {
             header('Content-Disposition: attachment; filename="' . $filename . '.pdf";');

--- a/action.php
+++ b/action.php
@@ -543,7 +543,11 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         global $INPUT;
         $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));
 
-        $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
+        $filename = 'Unknown';
+        if(!empty($this->title)) {
+            $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
+        }
+
         if($outputTarget === 'file') {
             header('Content-Disposition: attachment; filename="' . $filename . '.pdf";');
         } else {

--- a/action.php
+++ b/action.php
@@ -543,7 +543,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         global $INPUT;
         $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));
 
-        $filename = 'Unknown';
+        $filename = 'unknown';
         if(!empty($this->title)) {
             $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
         }

--- a/action.php
+++ b/action.php
@@ -548,7 +548,6 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));
 
         $filename = rawurlencode(cleanID(strtr($this->title, ':/;"', '    ')));
-
         if($outputTarget === 'file') {
             header('Content-Disposition: attachment; filename="' . $filename . '.pdf";');
         } else {


### PR DESCRIPTION
Currently, if the page doesn't have an page title the filename is only "pdf". With my change it would be "unkown.pdf", what would be better in my opinion.