### PR TITLE
Add exporting full namespace as menu button

### DIFF
--- a/MenuNSItem.php
+++ b/MenuNSItem.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace dokuwiki\plugin\dw2pdf;
+
+use dokuwiki\Menu\Item\AbstractItem;
+
+/**
+ * Class MenuItem
+ *
+ * Implements the PDF namespace export button for DokuWiki's menu system
+ *
+ * @package dokuwiki\plugin\dw2pdf
+ */
+class MenuNSItem extends AbstractItem
+{
+
+    /** @var string do action for this plugin */
+    protected $type = 'export_pdfns';
+
+    /** @var string icon file */
+    protected $svg = __DIR__ . '/file-pdf.svg';
+
+    /**
+     * MenuItem constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        global $REV, $DATE_AT, $ID;
+
+        if ($DATE_AT) {
+            $this->params['at'] = $DATE_AT;
+        } elseif ($REV) {
+            $this->params['rev'] = $REV;
+        }
+
+        $this->params['book_ns'] = getNS($ID);
+        $this->params['book_title'] = noNS(getNS($ID));
+    }
+
+    /**
+     * Get label from plugin language file
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        $hlp = plugin_load('action', 'dw2pdf');
+        return $hlp->getLang('export_pdfns_button');
+    }
+}

--- a/action.php
+++ b/action.php
@@ -975,8 +975,9 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function addsvgbutton(Doku_Event $event) {
-        global $INFO;
-        if($event->data['view'] != 'page' || !$this->getConf('showexportbutton')) {
+        global $INFO, $ID;
+
+        if($event->data['view'] != 'page') {
             return;
         }
 
@@ -984,6 +985,12 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             return;
         }
 
-        array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\dw2pdf\MenuItem()]);
+        if( $this->getConf('showexportbutton') ) {
+            array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\dw2pdf\MenuItem()]);
+        }
+
+        if( $this->getConf('showexportnsbutton') && getNS($ID) ) {
+            array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\dw2pdf\MenuNSItem()]);
+        }
     }
 }

--- a/action.php
+++ b/action.php
@@ -948,7 +948,11 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
     public function addbutton(Doku_Event $event) {
         global $ID, $REV, $DATE_AT;
 
-        if($this->getConf('showexportbutton') && $event->data['view'] == 'main') {
+        if(!$event->data['view'] == 'main') {
+            return;
+        }
+
+        if($this->getConf('showexportbutton')) {
             $params = array('do' => 'export_pdf');
             if($DATE_AT) {
                 $params['at'] = $DATE_AT;
@@ -964,6 +968,28 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
                           . '<span>' . $this->getLang('export_pdf_button') . '</span>'
                           . '</a>'
                           . '</li>'
+                ) +
+                array_slice($event->data['items'], -1, 1, true);
+        }
+
+        if($this->getConf('showexportnsbutton') && getNS($ID)) {
+            $params = array('do' => 'export_pdf');
+            if($DATE_AT) {
+                $params['at'] = $DATE_AT;
+            } elseif($REV) {
+                $params['rev'] = $REV;
+            }
+            $params['book_ns'] = getNS($ID);
+            $params['book_title'] = noNS(getNS($ID));
+
+            // insert button at position before last (up to top)
+            $event->data['items'] = array_slice($event->data['items'], 0, -1, true) +
+                array('export_pdfns' =>
+                    '<li>'
+                    . '<a href="' . wl($ID, $params) . '"  class="action export_pdf" rel="nofollow" title="' . $this->getLang('export_pdfns_button') . '">'
+                    . '<span>' . $this->getLang('export_pdfns_button') . '</span>'
+                    . '</a>'
+                    . '</li>'
                 ) +
                 array_slice($event->data['items'], -1, 1, true);
         }

--- a/conf/default.php
+++ b/conf/default.php
@@ -12,3 +12,4 @@ $conf['usecache']         = 1;
 $conf['usestyles']        = 'wrap,';
 $conf['qrcodesize']       = '120x120';
 $conf['showexportbutton'] = 1;
+$conf['showexportnsbutton'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -12,3 +12,4 @@ $meta['usecache']         = array('onoff');
 $meta['usestyles']        = array('string');
 $meta['qrcodesize']       = array('string', '_pattern' => '/^(|\d+x\d+)$/');
 $meta['showexportbutton'] = array('onoff');
+$meta['showexportnsbutton'] = array('onoff');

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,6 +1,7 @@
 <?php
 
 $lang['export_pdf_button'] = "Export to PDF";
+$lang['export_pdfns_button'] = "Export Namespace to PDF";
 $lang['needtitle']         = "Please provide a title.";
 $lang['needns']            = "Please provide an existing namespace.";
 $lang['notexist']          = "Requested page doesn't exist.";

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -23,3 +23,4 @@ $lang['usecache']                = 'Should PDFs be cached? Embedded images won\'
 $lang['usestyles']               = 'You can give a comma separated list of plugins of which the <code>style.css</code> or <code>screen.css</code> should be used for PDF generation. By default only <code>print.css</code> and <code>pdf.css</code> are used.';
 $lang['qrcodesize']              = 'Size of embedded QR code (in pixels <code><i>&lt;width&gt;</i><b>x</b><i>&lt;height&gt;</i></code>). Empty to disable';
 $lang['showexportbutton']        = 'Show PDF export button (only when supported by your template)';
+$lang['showexportnsbutton']      = 'Show PDF Namespace export button (only when supported by your template)';


### PR DESCRIPTION
This adds a second button to the menu to export the current namespace. I'm not sure how useful this is for the general public. A customer wanted it.