### PR TITLE
Change Google Infographics API to quickchart.io

### DIFF
--- a/action.php
+++ b/action.php
@@ -663,12 +663,12 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
     protected function page_depend_replacements($raw, $id) {
         global $REV, $DATE_AT;
 
-        // generate qr code for this page using google infographics api
+        // generate qr code for this page using quickchart.io (Google infographics api was deprecated in March 14, 2019)
         $qr_code = '';
         if($this->getConf('qrcodesize')) {
             $url = urlencode(wl($id, '', '&', true));
-            $qr_code = '<img src="https://chart.googleapis.com/chart?chs=' .
-                $this->getConf('qrcodesize') . '&cht=qr&chl=' . $url . '" />';
+            $qr_code = '<img src="https://quickchart.io/qr?size=' .
+                $this->getConf('qrcodesize') . '&text=' . $url . '&margin=1&ecLevel=Q" />';
         }
         // prepare replacements
         $replace['@ID@']      = $id;


### PR DESCRIPTION
The Google Infographics API was deprecated in 2012 and shut down on March 18, 2019. More information at https://developers.google.com/chart/infographics/