### PR TITLE
Update action.php

### DIFF
--- a/action.php
+++ b/action.php
@@ -233,7 +233,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
 //            }
 
             $json = new JSON(JSON_LOOSE_TYPE);
-            $list = $json->decode($INPUT->post->str('selection', '', true));
+            $list = $json->decode($INPUT->str('selection', '', true));
             if(!is_array($list) || empty($list)) {
                 http_status(400);
                 print $this->getLang('empty');


### PR DESCRIPTION
Change to works with all sending method of selection

An issue has been created related to this pull request https://github.com/splitbrain/dokuwiki-plugin-dw2pdf/issues/418

This change allow to DWPDF to accepte all selection sending method ( POST, GET, .. )