### PR TITLE
Use exception for error handling, add export of saved selections

### DIFF
--- a/action.php
+++ b/action.php
@@ -24,7 +24,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
     protected $tpl;
     /** @var string title of exported pdf */
     protected $title;
-    /** @var array list of pages inclued in exported pdf */
+    /** @var array list of pages included in exported pdf */
     protected $list = array();
     /** @var bool|string path to temporary cachefile */
     protected $onetimefile = false;

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -8,3 +8,4 @@ $lang['empty']             = "You don't have pages selected yet.";
 $lang['tocheader']         = "Table of Contents";
 $lang['export_ns']         = 'Export namespace "%s:" to file %s.pdf';
 $lang['forbidden']         = "You have no access to these pages: %s.<br/><br/>Use option 'Skip Forbidden Pages' to create your book with the available pages.";
+$lang['missingbookcreator'] = 'The Bookcreator Plugin is not installed or is disabled';

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -16,3 +16,4 @@ $lang['empty']                 = 'Er zijn nog geen pagina\'s geselecteerd.';
 $lang['tocheader']             = 'Inhoudsopgave';
 $lang['export_ns']             = 'Exporteren namespace "%s:" naar bestand %s.pdf';
 $lang['forbidden']             = 'Je hebt geen toegang tot deze pagina\'s: %s.<br/><br/>Gebruik de  optie \'Verboden pagina\'s overslaan\' om het boek te maken met de beschikbare pagina\'s.';
+$lang['missingbookcreator']     = 'De Bookcreator Plugin is niet geïnstalleerd of is uitgeschakeld';


### PR DESCRIPTION
- Error handling with use of exceptions
- saved selections can be stored with the bookmanager of bookcreator plugin. These can be exported directly from the page with the saved seleciton by `?do=export_pdfbook&savedselection=page_with_saved_selection`