### PR TITLE
Fix multi page rendering by setting global $INFO

### DIFF
--- a/action.php
+++ b/action.php
@@ -348,10 +348,17 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
 
         if(!file_exists($file)) return '';
 
-        //ensure $id is in global $ID (needed for parsing)
+        /*
+         * Ensure that global $ID and $INFO are set to match the page
+         * to be rendered in order for the rendering and other plugins
+         * to work properly.
+         */
         global $ID;
-        $keep = $ID;
-        $ID   = $id;
+        global $INFO;
+        $keepid = $ID;
+        $keepinfo = $INFO;
+        $ID = $id;
+        $INFO = pageinfo();
 
         if($rev || $date_at) {
             $ret = p_render('dw2pdf', p_get_instructions(io_readWikiPage($file, $id, $rev)), $info, $date_at); //no caching on old revisions
@@ -359,8 +366,9 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
             $ret = p_cached_output($file, 'dw2pdf', $id);
         }
 
-        //restore ID (just in case)
-        $ID = $keep;
+        // Restore ID and INFO (just in case)
+        $ID = $keepid;
+        $INFO = $keepinfo;
 
         return $ret;
     }


### PR DESCRIPTION
In case of rendering multiple pages into a single document, the context of the current page does not match the one of the pages
to be rendered. In some cases (e.g. with the struct plugin), the global $INFO is evaluated and as this is not set to match the page to be rendered, the struct plugin does not produce the expected output in the PDF.

Fix this by setting $INFO to match the current page to be rendered and restoring it afterwards.

In conjunction with cosmocode/dokuwiki-plugin-struct#574 this fixes the struct data output in multi-page PDFs.