### PR TITLE
Add header noindex, nofollow

### DIFF
--- a/action.php
+++ b/action.php
@@ -557,6 +557,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         header('Content-Type: application/pdf');
         header('Cache-Control: must-revalidate, no-transform, post-check=0, pre-check=0');
         header('Pragma: public');
+        header('X-Robots-Tag: noindex, nofollow');
         http_conditionalRequest(filemtime($cachefile));
         global $INPUT;
         $outputTarget = $INPUT->str('outputTarget', $this->getConf('output'));


### PR DESCRIPTION
Although the link do=export_pdf has a rel="nofollow" generated PDFs can be indexed.
Sending the header noindex prevents this.