### PR TITLE
Fix "Undefined array key" PHP warning with interwiki links

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -241,7 +241,7 @@ class renderer_plugin_dw2pdf extends Doku_Renderer_xhtml {
                 $img = DOKU_BASE . 'lib/images/interwiki.png';
             }
 
-            $link['name'] = '<img src="' . $img . '" width="16" height="16" style="vertical-align: center" class="' . $link['class'] . '" />' . $link['name'];
+            $link['name'] = '<img src="' . $img . '" width="16" height="16" style="vertical-align: middle" class="' . $link['class'] . '" />' . $link['name'];
         }
         return parent::_formatLink($link);
     }


### PR DESCRIPTION
This fixes #474 that was happening when mPDF was attempting to parse interwiki link "img" tags. The "vertical-align" property should use "middle" instead of "center", as "center" didn't exist as a value for this CSS property.