### PR TITLE
Use document language to set hyphenation and CJK support

### DIFF
--- a/DokuPDF.class.php
+++ b/DokuPDF.class.php
@@ -26,11 +26,10 @@ class DokuPDF extends \Mpdf\Mpdf
      * @param string $orientation
      * @param int $fontsize
      */
-    function __construct($pagesize = 'A4', $orientation = 'portrait', $fontsize = 11)
+    function __construct($pagesize = 'A4', $orientation = 'portrait', $fontsize = 11, $docLang = 'en')
     {
         global $conf;
         global $lang;
-        global $ID;
 
         if (!defined('_MPDF_TEMP_PATH')) define('_MPDF_TEMP_PATH', $conf['tmpdir'] . '/dwpdf/' . rand(1, 1000) . '/');
         io_mkdir_p(_MPDF_TEMP_PATH);
@@ -40,7 +39,6 @@ class DokuPDF extends \Mpdf\Mpdf
             $format .= '-L';
         }
 
-        $docLang = $this->getDocumentLanguage($ID);
         switch ($docLang) {
             case 'zh':
             case 'zh-tw':
@@ -95,25 +93,5 @@ class DokuPDF extends \Mpdf\Mpdf
         parent::GetFullPath($path, $basepath);
     }
 
-    /**
-     * Get the language of the current document
-     *
-     * Uses the translation plugin if available
-     * @return string
-     */
-    protected function getDocumentLanguage($pageid)
-    {
-        global $conf;
-
-        $lang = $conf['lang'];
-        /** @var helper_plugin_translation $trans */
-        $trans = plugin_load('helper', 'translation');
-        if ($trans) {
-            $tr = $trans->getLangPart($pageid);
-            if ($tr) $lang = $tr;
-        }
-
-        return $lang;
-    }
 
 }

--- a/action.php
+++ b/action.php
@@ -414,9 +414,12 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         // initialize PDF library
         require_once(dirname(__FILE__) . "/DokuPDF.class.php");
 
-        $mpdf = new DokuPDF($this->getExportConfig('pagesize'),
-                            $this->getExportConfig('orientation'),
-                            $this->getExportConfig('font-size'));
+        $mpdf = new DokuPDF(
+            $this->getExportConfig('pagesize'),
+            $this->getExportConfig('orientation'),
+            $this->getExportConfig('font-size'),
+            $this->getDocumentLanguage($this->list[0]) //use language of first page
+        );
 
         // let mpdf fix local links
         $self = parse_url(DOKU_URL);
@@ -1055,5 +1058,26 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
         }
 
         array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\dw2pdf\MenuItem()]);
+    }
+
+    /**
+     * Get the language of the current document
+     *
+     * Uses the translation plugin if available
+     * @return string
+     */
+    protected function getDocumentLanguage($pageid)
+    {
+        global $conf;
+
+        $lang = $conf['lang'];
+        /** @var helper_plugin_translation $trans */
+        $trans = plugin_load('helper', 'translation');
+        if ($trans) {
+            $tr = $trans->getLangPart($pageid);
+            if ($tr) $lang = $tr;
+        }
+
+        return $lang;
     }
 }


### PR DESCRIPTION
This uses the globally defined language or the language reported by the translation plugin.

As suggested here: https://forum.dokuwiki.org/d/20915-dw2pdf-with-language-dependent-hyphenation