### PR TITLE
Fixes Template load

### DIFF
--- a/action.php
+++ b/action.php
@@ -790,7 +790,7 @@ class action_plugin_dw2pdf extends DokuWiki_Action_Plugin {
                 $styleini = css_styleini($conf['template']);
             } else {
                 // Greebo functionality
-                $styleUtils = new \dokuwiki\StyleUtils();
+                $styleUtils = new \dokuwiki\StyleUtils($conf['template']);
                 $styleini = $styleUtils->cssStyleini($conf['template']); // older versions need still the template
             }
             $css = css_applystyle($css, $styleini['replacements']);


### PR DESCRIPTION
The template selected in "css_template" dropdown wasn't being respected because there was code changes on "cssStyleini" function on DokuWiki core.