### PR TITLE
require autoloader

### DIFF
--- a/DokuPDF.class.php
+++ b/DokuPDF.class.php
@@ -2,8 +2,9 @@
 
 // phpcs:disable: PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 
-use Mpdf\Mpdf;
 use dokuwiki\plugin\dw2pdf\DokuImageProcessorDecorator;
+use Mpdf\Mpdf;
+use Mpdf\MpdfException;
 
 /**
  * Wrapper around the mpdf library class
@@ -21,6 +22,9 @@ class DokuPDF extends Mpdf
      * @param string $pagesize
      * @param string $orientation
      * @param int $fontsize
+     *
+     * @throws MpdfException
+     * @throws Exception
      */
     public function __construct($pagesize = 'A4', $orientation = 'portrait', $fontsize = 11, $docLang = 'en')
     {

--- a/DokuPDF.class.php
+++ b/DokuPDF.class.php
@@ -27,8 +27,6 @@ class DokuPDF extends Mpdf
         global $conf;
         global $lang;
 
-        require_once __DIR__ . '/vendor/autoload.php';
-
         if (!defined('_MPDF_TEMP_PATH')) {
             define('_MPDF_TEMP_PATH', $conf['tmpdir'] . '/dwpdf/' . random_int(1, 1000) . '/');
         }

--- a/action.php
+++ b/action.php
@@ -542,7 +542,7 @@ class action_plugin_dw2pdf extends ActionPlugin
 
         $body_end .= '</div>';
 
-        $mpdf->WriteHTML($body_end, 2, false, true); // finish body html
+        $mpdf->WriteHTML($body_end, 2, false); // finish body html
         if ($isDebug) {
             $html .= $body_end;
             $html .= '</body>';
@@ -765,6 +765,8 @@ class action_plugin_dw2pdf extends ActionPlugin
 
     /**
      * Load all the style sheets and apply the needed replacements
+     *
+     * @return string css styles
      */
     protected function loadCSS()
     {
@@ -794,26 +796,19 @@ class action_plugin_dw2pdf extends ActionPlugin
             $css .= css_loadfile($file, $location);
         }
 
-        if (function_exists('css_parseless')) {
-            // apply pattern replacements
-            if (function_exists('css_styleini')) {
-                // compatiblity layer for pre-Greebo releases of DokuWiki
-                $styleini = css_styleini($conf['template']);
-            } else {
-                // Greebo functionality
-                $styleUtils = new StyleUtils();
-                $styleini = $styleUtils->cssStyleini($conf['template']); // older versions need still the template
-            }
-            $css = css_applystyle($css, $styleini['replacements']);
-
-            // parse less
-            $css = css_parseless($css);
+        // apply pattern replacements
+        if (function_exists('css_styleini')) {
+            // compatiblity layer for pre-Greebo releases of DokuWiki
+            $styleini = css_styleini($conf['template']);
         } else {
-            // @deprecated 2013-12-19: fix backward compatibility
-            $css = css_applystyle($css, DOKU_INC . 'lib/tpl/' . $conf['template'] . '/');
+            // Greebo functionality
+            $styleUtils = new StyleUtils();
+            $styleini = $styleUtils->cssStyleini($conf['template']); // older versions need still the template
         }
+        $css = css_applystyle($css, $styleini['replacements']);
 
-        return $css;
+        // parse less
+        return css_parseless($css);
     }
 
     /**

--- a/action.php
+++ b/action.php
@@ -41,6 +41,8 @@ class action_plugin_dw2pdf extends ActionPlugin
      */
     public function __construct()
     {
+        require_once __DIR__ . '/vendor/autoload.php';
+
         $this->tpl = $this->getExportConfig('template');
     }
 


### PR DESCRIPTION
recent cleanup #494 removed all the requires.
As long DokuWiki does not autoload vendor, a plugin has to do it.

@splitbrain or do I overlook something?