### PR TITLE
Feature: Template selection modal for PDF export

### DIFF
--- a/action.php
+++ b/action.php
@@ -25,6 +25,28 @@ use Mpdf\MpdfException;
 class action_plugin_dw2pdf extends ActionPlugin
 {
     /**
+     * action_plugin_dw2pdf constructor.
+     */
+    public function __construct()
+    {
+        global $JSINFO;
+
+        $this->loadConfig();
+
+        $JSINFO['plugins']['dw2pdf']['showexporttemplate'] = $this->getConf('showexporttemplate');
+
+        if ($this->getConf('showexporttemplate')) {
+            $templates = [$this->getConf('template')];
+            $dir = scandir(DOKU_PLUGIN . 'dw2pdf' . DIRECTORY_SEPARATOR . 'tpl');
+            foreach ($dir as $value) {
+                if (is_dir(DOKU_PLUGIN . 'dw2pdf' . DIRECTORY_SEPARATOR . 'tpl' . DIRECTORY_SEPARATOR . $value) && !in_array($value, array(".", "..", $this->getConf('template')))) {
+                    $templates[] = $value;
+                }
+            }
+            $JSINFO['plugins']['dw2pdf']['templates'] = json_encode($templates);
+        }
+    }
+    /**
      * Register the events
      *
      * @param EventHandler $controller

--- a/conf/default.php
+++ b/conf/default.php
@@ -15,3 +15,4 @@ $conf['usecache']         = 1;
 $conf['usestyles']        = 'wrap,';
 $conf['qrcodescale']       = '1';
 $conf['showexportbutton'] = 1;
+$conf['showexporttemplate'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -15,3 +15,4 @@ $meta['usecache']         = array('onoff');
 $meta['usestyles']        = array('string');
 $meta['qrcodescale']       = array('string', '_pattern' => '/^(|\d+(\.\d+)?)$/');
 $meta['showexportbutton'] = array('onoff');
+$meta['showexporttemplate'] = array('onoff');

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -10,3 +10,7 @@ $lang['export_ns']         = 'Export namespace "%s:" to file %s.pdf';
 $lang['forbidden']         = "You have no read access to the selected pages.";
 $lang['exportfailed']      = "The PDF could not be created.";
 $lang['missingbookcreator'] = 'The Bookcreator Plugin is not installed or is disabled';
+$lang['js']['export_pdf_modal'] = "Export to PDF";
+$lang['js']['template']    = 'Which template should be used for formatting the PDFs?';
+$lang['js']['cancel']      = 'Cancel';
+$lang['js']['export']      = 'Export';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -25,3 +25,4 @@ $lang['usecache']                = 'Should PDFs be cached? Embedded images won\'
 $lang['usestyles']               = 'You can give a comma separated list of plugins of which the <code>style.css</code> or <code>screen.css</code> should be used for PDF generation. By default only <code>print.css</code> and <code>pdf.css</code> are used.';
 $lang['qrcodescale']             = 'Size scaling of the embedded QR code. Empty or <code>0</code> to disable.';
 $lang['showexportbutton']        = 'Show PDF export button (only when supported by your template)';
+$lang['showexporttemplate']      = 'Show PDF export template selection';

--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -14,3 +14,7 @@ $lang['empty']                 = 'Você não selecionou nenhuma página.';
 $lang['tocheader']             = 'Índice';
 $lang['export_ns']             = 'Exportar domínio "%s:" para o arquivo %s.pdf';
 $lang['missingbookcreator']    = 'O plugin Bookcreator não está instalado ou está desativado';
+$lang['js']['export_pdf_modal'] = 'Exportar para PDF';
+$lang['js']['template']        = 'Qual modelo deve ser usado para formatar os PDFs?';
+$lang['js']['cancel']          = 'Cancelar';
+$lang['js']['export']          = 'Exportar';

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -25,3 +25,4 @@ $lang['usecache']              = 'Os PDFs devem ser armazenados em cache? Imagen
 $lang['usestyles']             = 'Você pode gerar uma lista de plugins separadas por vírgula nos quais <code>style.css</code> ou <code>screen.css</code> devem ser usadas para a gerar um PDF.';
 $lang['qrcodescale']           = 'Escala de tamanho do código QR incorporado. Vazio ou <code>0</code> para desativar.';
 $lang['showexportbutton']      = 'Mostrar botão de exportação de PDF (se suportado pelo modelo)';
+$lang['showexporttemplate']    = 'Mostrar seleção de template de exportação de PDF';

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+/**
+ * includes all needed JavaScript for the dw2pdf plugin
+ *
+ * be sure to touch this file when one of the scripts has been updated to refresh caching
+ */
+
+jQuery(function() {
+    /* DOKUWIKI:include script/template.js */
+});

--- a/script/template.js
+++ b/script/template.js
@@ -1,0 +1,107 @@
+/**
+ * Template dialog for end users
+ *
+ * @author Eduardo Mozart de Oliveira <eduardomozart182@gmail.com>
+ */
+(function () {
+    if (!JSINFO || !JSINFO.plugins.dw2pdf.showexporttemplate) return;
+
+
+    // basic dialog template
+    let $dialogSelect = '<select name="template" style="width:100%">';
+    jQuery.each(JSON.parse(JSINFO.plugins.dw2pdf.templates),function(index, value){
+        $dialogSelect += '<option value="' + value + '">' + value + '</option>'
+    });
+    $dialogSelect += '</select>';
+
+    const $dialog = jQuery(
+        '<div>' +
+        '<form>' +
+        '<label>' + LANG.plugins.dw2pdf.template + '<br>' +
+        $dialogSelect +
+        '</label>' +
+        '</form>' +
+        '</div>'
+    );
+
+    /**
+     * Executes the renaming based on the form contents
+     * @return {boolean}
+     */
+    const templateFN = function () {
+        window.location.href = jQuery('#dokuwiki__pagetools .action.export_pdf a').attr("href") + "&tpl=" + $dialog.find('select').find(':selected').text();
+
+        return true;
+    };
+
+    /**
+     * Create the actual dialog modal and show it
+     */
+    const showDialog = function () {
+        $dialog.dialog({
+            title: LANG.plugins.dw2pdf.export_pdf_modal + ' ' + JSINFO.id,
+            width: 800,
+            height: 200,
+            dialogClass: 'plugin_dw2pdf_dialog',
+            modal: true,
+            buttons: [
+                {
+                    text: LANG.plugins.dw2pdf.cancel,
+                    click: function () {
+                        $dialog.dialog("close");
+                    }
+                },
+                {
+                    text: LANG.plugins.dw2pdf.export,
+                    click: templateFN
+                }
+            ],
+            // remove HTML from DOM again
+            close: function () {
+                jQuery(this).remove();
+            }
+        });
+    };
+
+    /**
+     * Bind an event handler as the first handler
+     *
+     * @param {jQuery} $owner
+     * @param {string} event
+     * @param {function} handler
+     * @link https://stackoverflow.com/a/4700103
+     */
+    const bindFirst = function ($owner, event, handler) {
+        $owner.unbind(event, handler);
+        $owner.bind(event, handler);
+
+        const events = jQuery._data($owner[0])['events'][event];
+        events.unshift(events.pop());
+
+        jQuery._data($owner[0])['events'][event] = events;
+    };
+
+
+    // attach handler to menu item
+    jQuery('#dokuwiki__pagetools .action.export_pdf a')
+        .show()
+        .click(function (e) {
+            e.preventDefault();
+            showDialog();
+        });
+
+    // attach handler to mobile menu entry
+    const $mobileMenuOption = jQuery('form select[name=do] option[value=export_pdf]');
+    if ($mobileMenuOption.length === 1) {
+        bindFirst($mobileMenuOption.closest('select[name=do]'), 'change', function (e) {
+            const $select = jQuery(this);
+            if ($select.val() !== 'export_pdf') return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            $select.val('');
+            showDialog();
+        });
+    }
+
+})();


### PR DESCRIPTION
This PR introduces a template selection modal when exporting to PDF.

It adds a new `showexporttemplate` configuration option. When enabled, instead of exporting immediately, a dialog is presented asking the user which template they'd like to use. 

This approach provides a cleaner UI compared to rendering multiple export buttons (as proposed in #371), which can clutter the interface if a wiki has a large number of templates installed.