### PR TITLE
Feature: Custom fonts support per template

### DIFF
--- a/src/DokuMpdf.php
+++ b/src/DokuMpdf.php
@@ -32,6 +32,23 @@ class DokuMpdf extends Mpdf
         $initConfig = $config->getMPdfConfig();
         $initConfig['mode'] = $this->lang2mode($lang);
 
+        $tplfonts = DOKU_PLUGIN . 'dw2pdf/tpl/' . $config->getTemplateName() . '/fonts';
+        if (file_exists($tplfonts . '.php')) {
+            $defaultFontConfig = (new \Mpdf\Config\FontVariables())->getDefaults();
+            $fontData = $initConfig['fontdata'] ?? $defaultFontConfig['fontdata'];
+
+            $defaultConfig = (new \Mpdf\Config\ConfigVariables())->getDefaults();
+            $fontDirs = $initConfig['fontDir'] ?? $defaultConfig['fontDir'];
+            
+            $fontDirs[] = $tplfonts;
+            
+            $fontDefs = array($fontData, include($tplfonts . '.php'));
+            $fontData = array_reduce($fontDefs, 'array_merge', array());
+            
+            $initConfig['fontDir'] = $fontDirs;
+            $initConfig['fontdata'] = $fontData;
+        }
+
         $http = new HttpClient();
 
         $container = new SimpleContainer([

--- a/tpl/default/README.txt
+++ b/tpl/default/README.txt
@@ -67,3 +67,20 @@ Custom stylings can be provided in the following file of your dw2pdf-template fo
 You can use all the CSS that is understood by mpdf
 (See http://mpdf1.com/manual/index.php?tid=34)
 
+===== Fonts =====
+
+You can use custom fonts with your template by creating file ''fonts.php'' within your template folder. E.g.:
+
+<code>
+<?php
+return [
+    'frutiger' => [
+            'R' => 'Frutiger-Normal.ttf',
+            'I' => 'FrutigerObl-Normal.ttf',
+    ]
+];
+</code>
+
+Copy the font files to the ''fonts/'' subfolder within your template folder.
+
+You can use them on your template by using CSS style ''font-family: asap'', where "asap" is the name of the font on your ''fonts.php'' file.

--- a/tpl/default/README.txt
+++ b/tpl/default/README.txt
@@ -83,4 +83,4 @@ return [
 
 Copy the font files to the ''fonts/'' subfolder within your template folder.
 
-You can use them on your template by using CSS style ''font-family: asap'', where "asap" is the name of the font on your ''fonts.php'' file.
+You can use them on your template by using CSS style ''font-family: frutiger'', where "frutiger" is the name of the font on your ''fonts.php'' file.


### PR DESCRIPTION
This PR adds support for loading custom fonts directly from a template's directory. 

By creating a `fonts.php` configuration file and a `fonts/` subdirectory inside their template folder, template authors can now bundle custom `.ttf` fonts. Since the custom font loading is scoped strictly to the currently selected template being exported, it won't conflict globally or load unnecessary fonts.

The template `README.txt` has also been updated with instructions on how to use this new feature.

Sample: https://github.com/eduardomozart/ScriptUtil/tree/master/Scripts/DokuWiki/dw2pdf