### PR TITLE
Feature: Custom headers and footers for the last page

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -291,7 +291,23 @@ class Writer
         $html = $this->template->getHTML('back');
         if (!$html) return;
 
-        $this->conditionalPageBreak();
+        if ($this->breakBeforeNext) {
+            $this->write('<pagebreak page-selector="last-page" />', 2, false, false);
+            $this->breakBeforeNext = false;
+        }
+
+        $header = $this->template->getHTML('header', 'last');
+        $footer = $this->template->getHTML('footer', 'last');
+
+        if ($header) {
+            $this->mpdf->SetHTMLHeader($header, 'O');
+            $this->mpdf->SetHTMLHeader($header, 'E');
+        }
+        if ($footer) {
+            $this->mpdf->SetHTMLFooter($footer, 'O');
+            $this->mpdf->SetHTMLFooter($footer, 'E');
+        }
+
         $this->write($html, HTMLParserMode::HTML_BODY, false, false);
     }
 

--- a/tpl/default/README.txt
+++ b/tpl/default/README.txt
@@ -18,11 +18,13 @@ just the header.html is used.
   * ''header_odd.html'' -- Header for odd pages
   * ''header_even.html'' -- Header for even pages
   * ''header_first.html'' -- Header for the first page
+  * ''header_last.html'' -- Header for the last page
 
   * ''footer.html'' -- Footer for all pages
   * ''footer_odd.html'' -- Footer for odd pages
   * ''footer_even.html'' -- Footer for even pages
   * ''footer_first.html'' -- Footer for the first page
+  * ''footer_last.html'' -- Footer for the last page
 
   * ''citation.html'' -- Citationbox to be printed after each article
   * ''cover.html'' -- Added once before first page


### PR DESCRIPTION
This PR introduces support for `header_last.html` and `footer_last.html` templates. 

The `last-page` selector is injected via `<pagebreak page-selector="last-page" />` which is only added when `back.html` exists. This allows template authors to define custom headers and footers that only apply to the very last page of the exported document. 

The template `README.txt` has been updated to document these new files.

Sample: https://github.com/eduardomozart/ScriptUtil/tree/master/Scripts/DokuWiki/dw2pdf