### PR TITLE
Feature: @OLDREVISIONS@ placeholder for page changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor/*/*/test/*
 vendor/*/*/doc/*
 vendor/*/*/docs/*
 vendor/*/*/contrib/*
+.DS_Store

--- a/src/Template.php
+++ b/src/Template.php
@@ -202,9 +202,17 @@ class Template
     protected function changesToArray(string $id, int $limit = 50): array
     {
         if (empty($id)) return [];
-        require_once DOKU_INC . 'inc/changelog.php';
-        $pagelog = new \PageChangeLog($id);
-        return $pagelog->getRevisions(-1, $limit); // Get at most $limit revisions
+        $pagelog = new \dokuwiki\ChangeLog\PageChangeLog($id);
+        $revisions = $pagelog->getRevisions(-1, $limit); // Get at most $limit revisions
+        
+        $changes = [];
+        foreach ($revisions as $rev) {
+            $change = $pagelog->getRevisionInfo($rev);
+            if ($change !== false) {
+                $changes[] = $change;
+            }
+        }
+        return $changes;
     }
 
     /**
@@ -216,12 +224,27 @@ class Template
     protected function changesToHTML(array $changes): string
     {
         if (empty($changes)) return '';
+        
+        global $lang;
+        $date = $lang['media_sort_date'] ?? 'Date';
+        $userStr = $lang['media_sort_name'] ?? 'Name';
+        $summary = $lang['summary'] ?? 'Edit summary';
+
         $html = '<table class="changelog"><tbody>';
-        $html .= '<tr><th>Date</th><th>Author</th><th>Summary</th></tr>';
+        $html .= '<tr><th>' . hsc($date) . '</th><th>' . hsc($userStr) . '</th><th>' . hsc($summary) . '</th></tr>';
+        global $auth;
         foreach ($changes as $change) {
+            $user = $change['user'];
+            if ($auth && $user) {
+                $userData = $auth->getUserData($user);
+                if ($userData && !empty($userData['name'])) {
+                    $user = $userData['name'];
+                }
+            }
+
             $html .= '<tr>';
             $html .= '<td>' . dformat($change['date']) . '</td>';
-            $html .= '<td>' . hsc($change['user']) . '</td>';
+            $html .= '<td>' . hsc($user) . '</td>';
             $html .= '<td>' . hsc($change['sum']) . '</td>';
             $html .= '</tr>';
         }

--- a/src/Template.php
+++ b/src/Template.php
@@ -131,7 +131,6 @@ class Template
             '@UPDATE@' => dformat(filemtime(wikiFN($this->context['id'], $this->context['rev'] ?? ''))),
             '@PAGEURL@' => $url,
             '@QRCODE@' => $this->generateQRCode($url),
-            '@OLDREVISIONS@' => $this->changesToHTML($this->changesToArray($this->context['id'] ?? '')),
         ];
 
         // let other plugins define their own replacements
@@ -162,6 +161,16 @@ class Template
             $html
         );
 
+        // @OLDREVISIONS[(<limit>)]@
+        $html = preg_replace_callback(
+            '/@OLDREVISIONS(?:\((\d+)\))?@/',
+            function ($match) {
+                $limit = isset($match[1]) && is_numeric($match[1]) ? (int)$match[1] : 50;
+                return $this->changesToHTML($this->changesToArray($this->context['id'] ?? '', $limit));
+            },
+            $html
+        );
+
         return $html;
     }
 
@@ -187,14 +196,15 @@ class Template
      * Get revisions for a page
      *
      * @param string $id Page ID
+     * @param int $limit Max number of revisions to return
      * @return array
      */
-    protected function changesToArray(string $id): array
+    protected function changesToArray(string $id, int $limit = 50): array
     {
         if (empty($id)) return [];
         require_once DOKU_INC . 'inc/changelog.php';
         $pagelog = new \PageChangeLog($id);
-        return $pagelog->getRevisions(-1, 50); // Get at most 50 revisions
+        return $pagelog->getRevisions(-1, $limit); // Get at most $limit revisions
     }
 
     /**

--- a/src/Template.php
+++ b/src/Template.php
@@ -131,6 +131,7 @@ class Template
             '@UPDATE@' => dformat(filemtime(wikiFN($this->context['id'], $this->context['rev'] ?? ''))),
             '@PAGEURL@' => $url,
             '@QRCODE@' => $this->generateQRCode($url),
+            '@OLDREVISIONS@' => $this->changesToHTML($this->changesToArray($this->context['id'] ?? '')),
         ];
 
         // let other plugins define their own replacements
@@ -180,5 +181,42 @@ class Template
             $url,
             $this->qrScale
         );
+    }
+
+    /**
+     * Get revisions for a page
+     *
+     * @param string $id Page ID
+     * @return array
+     */
+    protected function changesToArray(string $id): array
+    {
+        if (empty($id)) return [];
+        require_once DOKU_INC . 'inc/changelog.php';
+        $pagelog = new \PageChangeLog($id);
+        return $pagelog->getRevisions(-1, 50); // Get at most 50 revisions
+    }
+
+    /**
+     * Format revisions as HTML table
+     *
+     * @param array $changes
+     * @return string
+     */
+    protected function changesToHTML(array $changes): string
+    {
+        if (empty($changes)) return '';
+        $html = '<table class="changelog"><tbody>';
+        $html .= '<tr><th>Date</th><th>Author</th><th>Summary</th></tr>';
+        foreach ($changes as $change) {
+            $html .= '<tr>';
+            $html .= '<td>' . dformat($change['date']) . '</td>';
+            $html .= '<td>' . hsc($change['user']) . '</td>';
+            $html .= '<td>' . hsc($change['sum']) . '</td>';
+            $html .= '</tr>';
+        }
+        $html .= '</tbody></table>';
+
+        return $html;
     }
 }

--- a/tpl/default/README.txt
+++ b/tpl/default/README.txt
@@ -57,7 +57,7 @@ In the headers and footers the ID of the bookmanager page of the Bookcreator is 
   * ''@PAGEURL@'' -- URL to the article
   * ''@UPDATE@'' -- Time of the last update of the article
   * ''@QRCODE@'' -- QR code image pointing to the original page url (requires an online generator, see config setting)
-  * ''@OLDREVISIONS@'' -- A table with the changelog of the current page
+  * ''@OLDREVISIONS@'' or ''@OLDREVISIONS(10)@'' -- A table with the changelog of the current page, optional parameter specifies the limit (default 50)
 
 ===== Styles =====
 

--- a/tpl/default/README.txt
+++ b/tpl/default/README.txt
@@ -57,6 +57,7 @@ In the headers and footers the ID of the bookmanager page of the Bookcreator is 
   * ''@PAGEURL@'' -- URL to the article
   * ''@UPDATE@'' -- Time of the last update of the article
   * ''@QRCODE@'' -- QR code image pointing to the original page url (requires an online generator, see config setting)
+  * ''@OLDREVISIONS@'' -- A table with the changelog of the current page
 
 ===== Styles =====
 


### PR DESCRIPTION
This PR introduces a new `@OLDREVISIONS@` placeholder that can be used in headers, footers, or cover pages. 

When used, it dynamically renders an HTML table containing the changelog of the exported page. By default, it displays up to the last 50 revisions. You can also specify a custom limit by providing a number in parentheses, such as `@OLDREVISIONS(10)@`, to show a specific number of recent revisions. The table includes the date, author, and edit summary for each revision. 

This feature is especially useful for generating official documentation PDFs that require an embedded revision history.

Sample: https://github.com/eduardomozart/ScriptUtil/blob/master/Scripts/DokuWiki/dw2pdf/nethouse/citation.html

<img width="615" height="642" alt="image" src="https://github.com/user-attachments/assets/b715ff8c-fa3b-49ce-ad64-935d630009cf" />
