### PR TITLE
fix ToC levels

### DIFF
--- a/_test/ConfigTest.php
+++ b/_test/ConfigTest.php
@@ -132,7 +132,20 @@ class ConfigTest extends DokuWikiTest
      */
     public function testDefaultTocLevels()
     {
-        $config = new Config(['toc' => 1]);
+        $config = new Config(['toc' => 1, 'toclevels' => '']);
+        $mpdfConfig = $config->getMPdfConfig();
+        $this->assertSame(['H1' => 0, 'H2' => 1, 'H3' => 2], $mpdfConfig['h2toc'], 'from toclevels');
+    }
+
+    /**
+     * Toc levels should reset to default when request parameter is set to empty string
+     */
+    public function testDefaultTocLevelsFromInput()
+    {
+        global $INPUT;
+        $INPUT->set('toclevels', '');
+
+        $config = new Config(['toc' => 1, 'toclevels' => '2-4']);
         $mpdfConfig = $config->getMPdfConfig();
         $this->assertSame(['H1' => 0, 'H2' => 1, 'H3' => 2], $mpdfConfig['h2toc'], 'from toclevels');
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -71,7 +71,7 @@ class Config
         io_mkdir_p($this->tempDir);
 
         // set default ToC levels from main config
-        $this->tocLevels = $this->parseTocLevels($conf['toptoclevel'] . '-' . $conf['maxtoclevel']);
+        $this->tocLevels = $this->parseTocLevels('');
 
         $this->loadPluginConfig($pluginConf);
         $this->loadInputConfig();
@@ -279,11 +279,19 @@ class Config
     /**
      * Parses the ToC levels configuration into an array
      *
+     * When no levels are given, the levels configured for the wiki's own ToC are used.
+     *
      * @param string $toclevels eg. "2-4"
      * @return array
      */
     protected function parseTocLevels(string $toclevels): array
     {
+        global $conf;
+
+        if (trim($toclevels) === '') {
+            $toclevels = $conf['toptoclevel'] . '-' . $conf['maxtoclevel'];
+        }
+
         $levels = [];
         [$top, $max] = sexplode('-', $toclevels, 2);
         $top = max(1, min(5, (int)$top));


### PR DESCRIPTION
This moves the handling of "no configuration" to parseTocLevels(). Fixes #551